### PR TITLE
Properly handle whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,44 @@
+#!/usr/bin/env node
+
 const mdjson = require('mdjson')
 const bl     = require('bl')
 
 process.stdin.pipe(bl(function(err, data) {
   if (err) throw err
 
-  var data = mdjson(data+'')
+  var data = (data+'').split('\n')
+  var head = null
+  var out  = {}
 
-  Object.keys(data).forEach(function(key) {
-    data[key] = data[key].raw
+  for (var i = 0; i < data.length; i++) {
+    var trim = data[i].trim()
+    var raw  = data[i]
+
+    if (trim.match(/^\#/g)) {
+      trim = trim.replace(/^\#+/g, '')
+      trim = trim.trim()
+      out[head = trim] = []
+      continue
+    }
+
+    if (head === null) continue
+
+    out[head].push(raw)
+  }
+
+  Object.keys(out).forEach(function(head) {
+    var group = out[head]
+    if (!group.length) return
+    if (!group[0].trim()) group.shift()
+    if (!group.length) return
+    if (!group[group.length - 1].trim()) group.pop()
+  })
+
+  Object.keys(out).forEach(function(head) {
+    out[head] = out[head].join('\n')
   })
 
   process.stdout.write('window.TEXTCHUNKS = ')
-  process.stdout.write(JSON.stringify(data, null, 2))
+  process.stdout.write(JSON.stringify(out, null, 2))
   process.stdout.write('\n')
 }))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@cabbibo/text-extract",
-  "bin": "text-extract",
+  "bin": {
+    "text-extract": "index.js"
+  },
   "dependencies": {
     "bl": "^0.9.4",
     "mdjson": "^1.0.0"


### PR DESCRIPTION
As promised :) This works more or less the same, except
it lets you have sequential line breaks in your markdown
and not have them collapsed.

If this isn't easily mergeable, you should be able to do:

``` bash
npm install -g 'hughsk/text-extract'
```

To use this version on your machine. Enjoy!
